### PR TITLE
Fixed null pointer exception in screenshot

### DIFF
--- a/src/main/java/io/ddavison/conductor/Locomotive.java
+++ b/src/main/java/io/ddavison/conductor/Locomotive.java
@@ -252,7 +252,7 @@ public class Locomotive implements Conductor<Locomotive> {
                 if (failure) {
                     ScreenShotUtil.take(Locomotive.this,
                             description.getDisplayName(),
-                            e.getMessage());
+                            e.getMessage() != null ? e.getMessage() : e.toString());
                 }
                 Locomotive.this.driver.quit();
             }


### PR DESCRIPTION
In some instances the exception thrown that triggers the screenshot taking does not have a message and it's equal to @null. Before using the message now I do a null check and use the exception name instead if it's null.